### PR TITLE
Multiplatform CMake build - ISSUE: #15

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,15 +2,32 @@
 #
 cmake_minimum_required (VERSION 2.8.12.2)
 
-if(${_CRF_SANITIZE_BUILD} STREQUAL "tsan")
-  set (CXX_SANITIZER_FLAGS "-fsanitize=thread -static-libtsan -fno-omit-frame-pointer")
-  message ("-- Making ThreadSanitize-d Build")
+# dispatch linking ThreadSanitizer lib based
+# on target platform
+#
+function (set_libtsan_link_flag)
+message ("-- Running on ${CMAKE_SYSTEM_NAME} platform")
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+  set (_CRF_LIBTSAN_LINK_FLAG "-static-libtsan")
+else(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+  set (_CRF_LIBTSAN_LINK_FALG "")
+endif()
+endfunction ()
+
+
+# setup sanitized build
+#
+if(${_CRF_SANITIZE_BUILD} STREQUAL "msan")
+  set (CXX_SANITIZER_FLAGS "-fsanitize=memory -fno-omit-frame-pointer")
+  message ("-- Making MemorySanitize-d Build")
 elseif(${_CRF_SANITIZE_BUILD} STREQUAL "asan")
   set (CXX_SANITIZER_FLAGS "-fsanitize=address -fno-omit-frame-pointer")
   message ("-- Making AddressSanitize-d Build")
 else(${_CRF_SANITIZE_BUILD} STREQUAL "msan")
-  set (CXX_SANITIZER_FLAGS "-fsanitize=memory -fno-omit-frame-pointer")
-endif(${_CRF_SANITIZE_BUILD} STREQUAL "tsan")
+  set_libtsan_link_flag ()
+  set (CXX_SANITIZER_FLAGS "-fsanitize=thread ${_CRF_LIBTSAN_LINK_FLAG} -fno-omit-frame-pointer")
+  message ("-- Making ThreadSanitize-d Build")
+endif(${_CRF_SANITIZE_BUILD} STREQUAL "msan")
 
 
 set (CXX_STANDARD "-std=c++14")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,12 +6,13 @@ cmake_minimum_required (VERSION 2.8.12.2)
 # on target platform
 #
 function (set_libtsan_link_flag)
-message ("-- Running on ${CMAKE_SYSTEM_NAME} platform")
-if(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+message ("-- Compiler ID: ${CMAKE_CXX_COMPILER_ID}")
+message ("-- Compiler Version: ${CMAKE_CXX_COMPILER_VERSION}")
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "5.3.0")
   set (_CRF_LIBTSAN_LINK_FLAG "-static-libtsan")
-else(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+else(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "5.3.0")
   set (_CRF_LIBTSAN_LINK_FALG "")
-endif()
+endif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "5.3.0")
 endfunction ()
 
 

--- a/cmk
+++ b/cmk
@@ -149,7 +149,7 @@ def clean_all(targets):
 def check_platform_support():
   # for platform info please see: https://docs.python.org/2/library/sys.html
   platform  = sys.platform
-  supported = [ 'linux2', 'darwin' ]
+  supported = [ 'linux', 'linux2', 'darwin' ]
   if not( platform in supported ):
     log.error('unsupported platform: %s' % platform)
     sys.exit(1)

--- a/cmk
+++ b/cmk
@@ -79,6 +79,7 @@ def args_of(argv):
   parser.add_argument('-v', '--verbose', action='store_true', help='triggers verbose compilation')
   parser.add_argument('-t', '--toolchain', help='sets the toolchain to build the project with', default='gcc', type=str, choices=supported_toolchains())
   parser.add_argument('--config-file', type=str, default='./cmk.json', help='sets the configuration JSON to be used instead the default - if no file is present the defaults will be used')
+  parser.add_argument('--dry-run', action='store_true', help='triggers a dry run - builds the cmake command and prints it to the standard output but executes not')
 
   mutex_g = parser.add_mutually_exclusive_group()
   mutex_g.add_argument('--asan', action='store_true', help='triggers build for running AddressSanitizer (ASan)')
@@ -97,9 +98,11 @@ def sanitizer_define_of(args):
 
 
 def make_commands(args, targets):
-  binutils_define   = '-D_CMAKE_TOOLCHAIN_PREFIX=llvm-' if ( args.toolchain == 'llvm' ) else ''
-  sanitizer_define  = sanitizer_define_of(args)
-  verbosity_defines = '-DCMAKE_RULE_MESSAGES=OFF -DCMAKE_VERBOSE_MAKEFILE=ON' if args.verbose else ''
+  binutils_define    = '-D_CMAKE_TOOLCHAIN_PREFIX=llvm-' if ( args.toolchain == 'llvm' ) else ''
+  sanitizer_define   = sanitizer_define_of(args)
+  verbosity_defines  = '-DCMAKE_RULE_MESSAGES=OFF -DCMAKE_VERBOSE_MAKEFILE=ON' if args.verbose else ''
+  makefile_generator = 'Unix Makefiles'
+  makefile_generator = '\"%s\"' % makefile_generator if args.dry_run else makefile_generator
   cmake_cmd = [ \
     'cmake', \
     binutils_define, \
@@ -107,9 +110,13 @@ def make_commands(args, targets):
     verbosity_defines, \
     '-DCMAKE_BUILD_TYPE=%s' % targets.build_type, \
     '-D_CRF_INSTALL_HOME=%s' % targets.install_home, \
-    '-G', 'Unix Makefiles', \
+    '-G', makefile_generator, \
     targets.source_dir  \
   ]
+  if args.dry_run:
+    log.info('command: %s' % ' '.join(cmake_cmd))
+    sys.exit(0)
+
   make_cmd  = ['make', ]
   if args.verbose:
     make_cmd.extend([ 'VERBOSE=1', '--no-print-directory' ])
@@ -127,7 +134,7 @@ def setup_env(args, env):
 
 
 def execute(command):
-  log.debug(' '.join(command))
+  log.debug('executing: %s' % ' '.join(command))
   exit_status = sp.call(command)
   return int(exit_status)
 


### PR DESCRIPTION
Needed ***some refinements*** as on Arch Linux there is no static libtsan and the platform indicator changed from python 2.x to 3.x (yes, unfortunately 3.x is the default python version on Arch Linux).

Added  ***dry run support*** to display the cmake command only after it is constructed - some hack regarding escaping the Generator name to be run from python subprocess and command line.

### Update ####

* `GCC` ***does not support*** `MemorySanitizer`, only `Clang` does :(
* `LLVM` could be set as the ***default toolchain***
* the ***default sanitizer*** is set to be the `ThreadSanitizer`